### PR TITLE
--hub_push_path now creates private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains functionality to download data and prepare BROAD, an image ev
 
 After installing requirements, the dataset can be built using the `build_broad.py` script. The following example will generate the entire dataset including the componenets that depend on imagenet and coco. This behaviour can be modified by dropping the ` --imagenet-based` or `--coco-based` options.
 
-Note that outputs can be saved to disk and/or pushed to a huggingface repo. Also, downloading datasets might require logging in to huggingface's hub beforehand (i.e., `huggingface-cli login`).
+Note that outputs can be saved to disk and/or pushed to a private[^1] huggingface repo. Also, downloading datasets might require logging in to huggingface's hub beforehand (i.e., `huggingface-cli login`).
 
 ```
 python build_broad.py \
@@ -18,3 +18,5 @@ python build_broad.py \
 ```
 
 The bulk of the building time is given by the downloading of the two auxiliary datasets, and a couple of hours should be expected with a reasonable download speed.
+
+[^1]: For licensing reasons, the output of `build_broad.py` cannot be uploaded to a public huggingface repository.

--- a/build_broad.py
+++ b/build_broad.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--hub_push_path",
-        help="Optional hugging face datasets where to push the BROAD processed dataset.",
+        help="Optional private hugging face datasets where to push the BROAD processed dataset.",
     )
 
     args = parser.parse_args()
@@ -48,4 +48,5 @@ if __name__ == "__main__":
         broad.save_to_disk(args.output_dir)
     
     if args.hub_push_path is not None:
-        broad.push_to_hub(args.hub_push_path)
+        # The repository must be private because it contains data that you are not licensed to distribute.
+        broad.push_to_hub(args.hub_push_path, private=True)


### PR DESCRIPTION
For licensing reasons, the output of `build_broad.py` cannot be uploaded to a public huggingface repository. After this change, specifying a `--hub_push_path` will create a private huggingface repository.